### PR TITLE
Clang warnings fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,21 +1,25 @@
 node {
-    //sh 'env > env.txt'
-    //for (String i : readFile('env.txt').split("\r?\n")) {
-    //    println i
-    //}
 
     sh "echo \$PWD"
 
     stage('Preparation') { // for display purposes
-
         // Get some code from a GitHub repository
         git 'https://github.com/BenjaFriend/Weave_Engine.git'
     }
 
-    stage('Build') {
-       echo 'Hello I am in the buiiild stage!'
+    stage('Build Server GCC') {
+       echo 'Building with GCC...'
+       sh "g++ --version"
        // Run CMake here, maybe inside a docker container?
-       sh "cmake \$PWD/Weave_Server"
+       sh "cmake \$PWD/Weave_Server -DUSE_CLANG=OFF"
+       sh "make \$PWD/Weave_Server"
+    }
+
+    stage('Build Server Clang') {
+       echo 'Building with Clang...'
+       sh "clang++ --version"
+       // Run CMake here, maybe inside a docker container?
+       sh "cmake \$PWD/Weave_Server -DUSE_CLANG=ON"
        sh "make \$PWD/Weave_Server"
     }
 

--- a/Weave_Common/ECS/ComponentManager.h
+++ b/Weave_Common/ECS/ComponentManager.h
@@ -50,12 +50,10 @@ namespace ECS
         /// <param name="...args">Arguments for your component's constructor</param>
         /// <returns>Pointer to the newly created component</returns>
         template<class T, class ...ARGS>
-        T* AddComponent( IEntity* aEntity, ARGS&&... args )
+        T* AddComponent( IEntity* aEntity, const ECS::EntityID aEntityID, ARGS&&... args )
         {
             assert( aEntity != nullptr );
             const ComponentTypeId CTID = T::STATIC_COMPONENT_TYPE_ID;
-
-            const ECS::EntityID aEntityID = aEntity->GetID();
 
             // Make sure that this component doesn't exist already
             assert( this->activeComponents [ aEntityID ] [ CTID ] == nullptr );

--- a/Weave_Common/Entity/IEntity.h
+++ b/Weave_Common/Entity/IEntity.h
@@ -86,6 +86,7 @@ public:
         return
             this->componentManager->AddComponent<T>(
                 this,
+                this->entID,
                 std::forward<P>( param )...
                 );
     }

--- a/Weave_Common/Utils/ObjectPool.hpp
+++ b/Weave_Common/Utils/ObjectPool.hpp
@@ -13,7 +13,7 @@ public:
 
     ~ObjectPool();
 
-    FORCE_INLINE const bool IsEmpty() const { AvailableIndecies.empty(); }
+    FORCE_INLINE const bool IsEmpty() const { return AvailableIndecies.empty(); }
 
     FORCE_INLINE const bool IsFull() const { return AvailableIndecies.size() == MaxSize; }
 

--- a/Weave_Server/Weave_Server/CMakeLists.txt
+++ b/Weave_Server/Weave_Server/CMakeLists.txt
@@ -13,6 +13,13 @@ set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/_Output/$<CONFIG> )
 # Sets the output directory
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY "bin" )
 
+option( USE_CLANG "build application with clang" OFF ) # OFF is the default
+
+if( USE_CLANG )
+    set( CMAKE_C_COMPILER   "/usr/bin/clang" )
+    set( CMAKE_CXX_COMPILER "/usr/bin/clang++" )
+endif( USE_CLANG )
+
 message( STATUS "Using compiler:\t " ${CMAKE_CXX_COMPILER} )
 
 ################# Add Boost #####################
@@ -86,7 +93,7 @@ message ( STATUS "LINK_DIRS: " ${LINK_DIRS} )
 if( MSVC )
     set ( MY_COMPILER_FLAGS "/W3" )
 else()
-    set ( MY_COMPILER_FLAGS "-Wall -Wno-reorder" )
+    set ( MY_COMPILER_FLAGS "-Wall -Wno-reorder -Wno-unknown-pragmas -Wno-multichar" )
 endif()
 
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MY_COMPILER_FLAGS}" )

--- a/Weave_Server/Weave_Server/include/ServerUtils.h
+++ b/Weave_Server/Weave_Server/include/ServerUtils.h
@@ -21,14 +21,15 @@ struct SERVER_INIT_DESC
     unsigned short MaxRooms = 4;
 
     /** The time between client state updates on the server */
-    float StateUpdateTickRate = 1.0f;
+    float StateUpdateTickRate = 0.5f;
 
     friend std::ostream& operator<<( std::ostream& os, const SERVER_INIT_DESC& data )
     {
         os << "\nServer Config";
         os << "\n\tListen Port: \t" << data.ListenPort;
         os << "\n\tResponse Port: \t" << data.ResponsePort;
-        os << "\n\tMax Rooms: \t" << data.MaxRooms << "\n";
+        os << "\n\tMax Rooms: \t" << data.MaxRooms;
+        os << "\n\tTickRate: \t" << data.StateUpdateTickRate << "\n";
         return os;
     }
 };

--- a/Weave_Server/Weave_Server/include/WeaveServer.h
+++ b/Weave_Server/Weave_Server/include/WeaveServer.h
@@ -78,7 +78,11 @@ private:
     /** The thread the user input will be checked on */
     std::thread userInputThread;
 
+    /** Delta time of the server */
+    float DeltaTime;
 
+    /** Total time that the program has been running */
+    float TotalTime;
 
     /** Time between input updates */
     float TimeOfLastStateUpdate;

--- a/Weave_Server/Weave_Server/src/WeaveServer.cpp
+++ b/Weave_Server/Weave_Server/src/WeaveServer.cpp
@@ -9,6 +9,10 @@ WeaveServer::WeaveServer( SERVER_INIT_DESC aDesc )
     ResponsePort( aDesc.ResponsePort ),
     TimeBetweenStateUpdates( aDesc.StateUpdateTickRate )
 {
+    // #TODO: Set up a room concept for the server
+    ( void )( ResponsePort );
+    ( void )( MaxRooms );
+
     NetworkMan = new ServerNetworkManager();
     NetworkMan->Init( ListenPort );
 

--- a/Weave_Server/Weave_Server/src/WeaveServer.cpp
+++ b/Weave_Server/Weave_Server/src/WeaveServer.cpp
@@ -49,16 +49,16 @@ void WeaveServer::Run()
         if ( ShouldQuit ) break;
 
         Timing::sInstance.Update();
-        float deltaTime = Timing::sInstance.GetDeltaTime();
-        float totalTime = Timing::sInstance.GetTimef();
+        DeltaTime = Timing::sInstance.GetDeltaTime();
+        TotalTime = Timing::sInstance.GetTimef();
 
         NetworkMan->ProcessIncomingPackets();
 
         // If we have hit our tick rate, then update all clients
-        if ( totalTime > TimeOfLastStateUpdate + TimeBetweenStateUpdates )
+        if ( TotalTime > TimeOfLastStateUpdate + TimeBetweenStateUpdates )
         {
             NetworkMan->UpdateAllClients();
-            TimeOfLastStateUpdate = totalTime;
+            TimeOfLastStateUpdate = TotalTime;
         }
 
         // Update the rooms and scenes here

--- a/Weave_Server/server.conf
+++ b/Weave_Server/server.conf
@@ -1,4 +1,5 @@
 ServerName : TestServer
-ListenPort : 50000
-ResponsePort : 50001
+ListenPort : 50001
+ResponsePort : 50011
 MaxRooms : 4
+TickRate : 0.5


### PR DESCRIPTION
The server now compiles with `Clang` on Ubuntu and ignores pragma regions and multichar warnings 