### PR TITLE
Dll crash fix

### DIFF
--- a/Weave_Common/Entity/IEntity.cpp
+++ b/Weave_Common/Entity/IEntity.cpp
@@ -39,10 +39,7 @@ void IEntity::Write( OutputMemoryBitStream & inOutputStream, UINT32 inDirtyState
 
 void IEntity::Read( InputMemoryBitStream & inInputStream )
 {
-    //size_t ID = {};
-    //inInputStream.Read( ID );
-
-    glm::vec3 readPos = {};
+    glm::vec3 readPos( 0.f );
     inInputStream.Read( readPos.x );
     inInputStream.Read( readPos.y );
     inInputStream.Read( readPos.z );

--- a/Weave_Common/Logging/Logger.h
+++ b/Weave_Common/Logging/Logger.h
@@ -55,7 +55,7 @@ private:
 // Current print format: 
 // LOG_TRACE ( "This is an example of {}", "this" );
 
-#if defined( DEBUG ) || defined ( _DEBUG )
+#if defined( DEBUG ) || defined ( _DEBUG ) || defined ( W_ENABLE_LOGGING )
 
 #define  LOG_TRACE( ... )    Logger::GetCurrentConsole()->info( __VA_ARGS__ )
 #define  LOG_WARN( ... )     Logger::GetCurrentConsole()->warn( __VA_ARGS__ )

--- a/Weave_Common/Networking/NetworkManager.cpp
+++ b/Weave_Common/Networking/NetworkManager.cpp
@@ -10,10 +10,11 @@ std::shared_ptr< boost::asio::ip::udp::socket > UDPSocketFactory(
     return std::make_shared< boost::asio::ip::udp::socket >( service, aEnpoint );
 }
 
-NetworkManager::NetworkManager()
+NetworkManager::NetworkManager( std::shared_ptr< boost::asio::io_service > aServce )
 {
     // Create an IO service
-    io_service = std::make_unique< boost::asio::io_service >();
+    //io_service = std::make_shared< boost::asio::io_service >();
+    io_service = aServce;
 }
 
 NetworkManager::~NetworkManager()

--- a/Weave_Common/Networking/NetworkManager.cpp
+++ b/Weave_Common/Networking/NetworkManager.cpp
@@ -6,12 +6,13 @@ namespace bai = boost::asio::ip;
 
 NetworkManager::NetworkManager()
 {
-
+    // Create an IO service
+    io_service = std::make_unique< boost::asio::io_service >();
 }
 
 NetworkManager::~NetworkManager()
 {
-    io_service.stop();
+    io_service->stop();
     IsDone = true;
 
     if ( runningThread.joinable() )
@@ -26,7 +27,7 @@ bool NetworkManager::Init( UINT16 aPort )
 {
     // Create a new UDP socket on the given port
     std::shared_ptr< bai::udp::socket > wat(
-        new bai::udp::socket( io_service, bai::udp::endpoint( bai::udp::v4(), aPort ) )
+        new bai::udp::socket( *io_service, bai::udp::endpoint( bai::udp::v4(), aPort ) )
     );
 
     ListenSocket = std::move( wat );
@@ -65,12 +66,12 @@ void NetworkManager::Run()
 {
     StartRecieve();
 
-    while ( !IsDone || !io_service.stopped() )
+    while ( !IsDone || !io_service->stopped() )
     {
         // Run said server
         try
         {
-            io_service.run();
+            io_service->run();
         }
         catch ( const std::exception& e )
         {

--- a/Weave_Common/Networking/NetworkManager.cpp
+++ b/Weave_Common/Networking/NetworkManager.cpp
@@ -54,9 +54,9 @@ void NetworkManager::SendPacket( const OutputMemoryBitStream & inOutputStream, c
 {
     // Send the output stream to the given endpoint
     // returns the number of bytes send
-    ListenSocket->send_to( 
+    ListenSocket->send_to(
         boost::asio::buffer( inOutputStream.GetBufferPtr(), inOutputStream.GetBitLength() ),
-        inFromAddress 
+        inFromAddress
     );
     // #TODO Keep track of the number of bytes sent this frame
 }
@@ -68,9 +68,18 @@ void NetworkManager::Run()
     while ( !IsDone || !io_service.stopped() )
     {
         // Run said server
-        io_service.run();
-
-        LOG_TRACE( "Server iteration next!" );
+        try
+        {
+            io_service.run();
+        }
+        catch ( const std::exception& e )
+        {
+            LOG_ERROR( "Server: Network exception: {}", e.what() );
+        }
+        catch ( ... )
+        {
+            LOG_ERROR( "Server: Network exception: UNKNOWN" );
+        }
     }
 }
 
@@ -125,6 +134,6 @@ void NetworkManager::HandleRemoteRecieved( const std::error_code & error, std::s
 NetworkManager::ReceivedPacket::ReceivedPacket( float inRecievedtime, InputMemoryBitStream & inStream, boost::asio::ip::udp::endpoint & aInEndpoint ) :
     Recievedtime( inRecievedtime ),
     PacketBuffer( inStream ),
-    InEndpoint ( aInEndpoint )
+    InEndpoint( aInEndpoint )
 {
 }

--- a/Weave_Common/Networking/NetworkManager.cpp
+++ b/Weave_Common/Networking/NetworkManager.cpp
@@ -4,6 +4,12 @@
 
 namespace bai = boost::asio::ip;
 
+std::shared_ptr< boost::asio::ip::udp::socket > UDPSocketFactory( 
+    boost::asio::io_service & service, bai::udp::endpoint& aEnpoint )
+{
+    return std::make_shared< boost::asio::ip::udp::socket >( service, aEnpoint );
+}
+
 NetworkManager::NetworkManager()
 {
     // Create an IO service
@@ -25,12 +31,7 @@ NetworkManager::~NetworkManager()
 
 bool NetworkManager::Init( UINT16 aPort )
 {
-    // Create a new UDP socket on the given port
-    std::shared_ptr< bai::udp::socket > wat(
-        new bai::udp::socket( *io_service, bai::udp::endpoint( bai::udp::v4(), aPort ) )
-    );
-
-    ListenSocket = std::move( wat );
+    ListenSocket = UDPSocketFactory( *io_service, bai::udp::endpoint( bai::udp::v4(), aPort ) );
 
     LOG_TRACE( "Initalize Network manager at port {}", aPort );
 

--- a/Weave_Common/Networking/NetworkManager.h
+++ b/Weave_Common/Networking/NetworkManager.h
@@ -121,7 +121,7 @@ private:
     std::shared_ptr< boost::asio::ip::udp::socket > ListenSocket;
 
     /** Io service for running the sockets */
-    boost::asio::io_service io_service;
+    std::unique_ptr < boost::asio::io_service > io_service;
 
     /** the endpoint of the remote client contacting the server */
     boost::asio::ip::udp::endpoint remote_endpoint;

--- a/Weave_Common/Networking/NetworkManager.h
+++ b/Weave_Common/Networking/NetworkManager.h
@@ -28,12 +28,12 @@ class NetworkManager
 public:
 
     // Packet types
-    static const UINT32 HelloPacket     = 'HELO';   // Hello packet from the client
-    static const UINT32 WelcomePacket   = 'WELC';   // Welcome packet to initialize the client
-    static const UINT32 StatePacket     = 'STAT';   // State update of the scene
-    static const UINT32	InputPacket     = 'INPT';   // The client's input state
+    static const UINT32 HelloPacket = 'HELO';   // Hello packet from the client
+    static const UINT32 WelcomePacket = 'WELC';   // Welcome packet to initialize the client
+    static const UINT32 StatePacket = 'STAT';   // State update of the scene
+    static const UINT32	InputPacket = 'INPT';   // The client's input state
 
-    NetworkManager();
+    NetworkManager( std::shared_ptr< boost::asio::io_service > aServce );
 
     virtual ~NetworkManager();
 
@@ -54,6 +54,12 @@ public:
     /// <param name="inOutputStream">Data to send within this packet</param>
     /// <param name="inFromAddress">The endpoint to send this data to</param>
     void SendPacket( const OutputMemoryBitStream& inOutputStream, const boost::asio::ip::udp::endpoint & inFromAddress );
+
+    /*void SetIOServce( std::unique_ptr < boost::asio::io_service > aService )
+    {
+        io_service.release();
+        io_service = std::move( aService );
+    }*/
 
 protected:
 
@@ -121,7 +127,7 @@ private:
     std::shared_ptr< boost::asio::ip::udp::socket > ListenSocket;
 
     /** Io service for running the sockets */
-    std::unique_ptr < boost::asio::io_service > io_service;
+    std::shared_ptr < boost::asio::io_service > io_service;
 
     /** the endpoint of the remote client contacting the server */
     boost::asio::ip::udp::endpoint remote_endpoint;

--- a/Weave_Common/Networking/NetworkManager.h
+++ b/Weave_Common/Networking/NetworkManager.h
@@ -55,12 +55,6 @@ public:
     /// <param name="inFromAddress">The endpoint to send this data to</param>
     void SendPacket( const OutputMemoryBitStream& inOutputStream, const boost::asio::ip::udp::endpoint & inFromAddress );
 
-    /*void SetIOServce( std::unique_ptr < boost::asio::io_service > aService )
-    {
-        io_service.release();
-        io_service = std::move( aService );
-    }*/
-
 protected:
 
     /** Check for if we are done or not */

--- a/Weave_Common/stdafx.h
+++ b/Weave_Common/stdafx.h
@@ -20,8 +20,11 @@
 #include <fstream>
 #include <tuple>
 
-#include "Logging/Logger.h"    // Logging definitions to only happen in debug
-#include "MathHelper.h"     // Math definitions and typedefs
+#define W_ENABLE_LOGGING        // Define this to enable logging in release mode 
+                                // Make sure it's before Logger.h  include
+
+#include "Logging/Logger.h"     // Logging definitions to only happen in debug
+#include "MathHelper.h"         // Math definitions and typedefs
 
 /**************************************************************/
 /* Runtime Options                                            */

--- a/Weave_Common/stdafx.h
+++ b/Weave_Common/stdafx.h
@@ -20,7 +20,7 @@
 #include <fstream>
 #include <tuple>
 
-#define W_ENABLE_LOGGING        // Define this to enable logging in release mode 
+//#define W_ENABLE_LOGGING        // Define this to enable logging in release mode 
                                 // Make sure it's before Logger.h  include
 
 #include "Logging/Logger.h"     // Logging definitions to only happen in debug

--- a/Weave_Engine/TankGame/Game/TankGame.cpp
+++ b/Weave_Engine/TankGame/Game/TankGame.cpp
@@ -107,7 +107,9 @@ void Tanks::TankGame::DrawMainMenu()
     if ( ImGui::Button( "Connect", ImVec2( ImGui::GetWindowWidth(), 0.f ) ) )
     {
         // Attempt to connect to the server
-        NetMan = ClientNetworkManager::StaticInit( serverAddressBuf, serverPortBuf, namebuf );
+        io_service.reset();
+        io_service = std::make_shared< boost::asio::io_service >();
+        NetMan = ClientNetworkManager::StaticInit( io_service, serverAddressBuf, serverPortBuf, namebuf );
         GameState = EGameState::Playing;
     }
 

--- a/Weave_Engine/TankGame/Game/TankGame.h
+++ b/Weave_Engine/TankGame/Game/TankGame.h
@@ -3,6 +3,8 @@
 #include <Core/Game.h>
 #include "../Networking/ClientNetworkManager.h"
 #include "PlayerMoves.h"
+#include <boost/asio.hpp>
+#include <memory>
 
 namespace Tanks
 {
@@ -57,6 +59,12 @@ namespace Tanks
         void DrawGameUI();
 
     private:
+
+        /** Pointer to the io_service for the network manager
+        * This has to be here because otherwise there is an exception on exit
+        * in release mode when the netMan io_service goes out of context
+        */
+        std::shared_ptr < boost::asio::io_service > io_service;
 
         /** Network manager for this tank game */
         ClientNetworkManager* NetMan = nullptr;

--- a/Weave_Engine/TankGame/Networking/ClientNetworkManager.cpp
+++ b/Weave_Engine/TankGame/Networking/ClientNetworkManager.cpp
@@ -134,7 +134,7 @@ void Tanks::ClientNetworkManager::SendInputPacket()
         output.Write( InputPacket );
 
         // For every move in the queue
-        const std::deque<Input::InputType> moveQueue = PlayerMoves::Instance->GetMoveQueue();
+        const std::deque<Input::InputType> & moveQueue = PlayerMoves::Instance->GetMoveQueue();
 
         // Write the size of how many moves there are
         output.Write( static_cast< UINT32 > ( moveQueue.size() ) );

--- a/Weave_Engine/TankGame/Networking/ClientNetworkManager.cpp
+++ b/Weave_Engine/TankGame/Networking/ClientNetworkManager.cpp
@@ -8,8 +8,8 @@ using namespace Tanks;
 ClientNetworkManager* ClientNetworkManager::Instance = nullptr;
 
 
-ClientNetworkManager::ClientNetworkManager( const char * aServerAddr, const unsigned short aPort, const std::string& aName )
-    : NetworkManager()
+ClientNetworkManager::ClientNetworkManager( std::shared_ptr< boost::asio::io_service > aService, const char * aServerAddr, const unsigned short aPort, const std::string& aName )
+    : NetworkManager( aService )
 {
     ServerEndpoint =
         boost::asio::ip::udp::endpoint(
@@ -27,11 +27,15 @@ ClientNetworkManager::~ClientNetworkManager()
 
 }
 
-ClientNetworkManager* Tanks::ClientNetworkManager::StaticInit( const char * aServerAddr, const unsigned short aPort, const std::string& aName )
+ClientNetworkManager* Tanks::ClientNetworkManager::StaticInit( 
+    std::shared_ptr< boost::asio::io_service > aService,
+    const char * aServerAddr,
+    const unsigned short aPort,
+    const std::string& aName )
 {
     assert( Instance == nullptr );
 
-    Instance = new ClientNetworkManager( aServerAddr, aPort, aName );
+    Instance = new ClientNetworkManager( aService, aServerAddr, aPort, aName );
     Instance->Init( 50000 );
 
     LOG_TRACE( "Client initalized!" );

--- a/Weave_Engine/TankGame/Networking/ClientNetworkManager.h
+++ b/Weave_Engine/TankGame/Networking/ClientNetworkManager.h
@@ -28,7 +28,11 @@ namespace Tanks
         
         static ClientNetworkManager* Instance;
 
-        static ClientNetworkManager* StaticInit( const char * aServerAddr, const unsigned short aPort, const std::string& aName );
+        static ClientNetworkManager* StaticInit( 
+            std::shared_ptr< boost::asio::io_service > aService,
+            const char * aServerAddr,
+            const unsigned short aPort,
+            const std::string& aName );
 
         /// <summary>
         /// Delete the static instance of the network manager
@@ -51,7 +55,10 @@ namespace Tanks
 
     protected:
 
-        ClientNetworkManager( const char * aServerAddr, const unsigned short aPort, const std::string& aName );
+        ClientNetworkManager( std::shared_ptr< boost::asio::io_service > aService,
+            const char * aServerAddr, 
+            const unsigned short aPort,
+            const std::string& aName );
 
         virtual ~ClientNetworkManager();
 

--- a/Weave_Engine/TankGame/TankGame.vcxproj
+++ b/Weave_Engine/TankGame/TankGame.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebugInfo|Win32">
+      <Configuration>RelWithDebugInfo</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebugInfo|x64">
+      <Configuration>RelWithDebugInfo</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
@@ -39,6 +47,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -46,6 +61,13 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>llvm</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>llvm</PlatformToolset>
@@ -63,10 +85,16 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -85,7 +113,17 @@
     <OutDir>$(ProjectDir)_Output\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>_Intermediate\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)_Output\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>_Intermediate\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)_Output\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>_Intermediate\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(ProjectDir)_Output\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>_Intermediate\$(Platform)\$(Configuration)\</IntDir>
@@ -96,6 +134,11 @@
     <UseLldLink>false</UseLldLink>
   </PropertyGroup>
   <PropertyGroup Label="LLVM" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <UseClangCl>false</UseClangCl>
+    <ClangClAdditionalOptions>-std=c++11 -Wc++11-narrowing -fsyntax-only  -Wmicrosoft-include -v --relocatable-pch -Wall -Wextra -pedantic</ClangClAdditionalOptions>
+    <UseLldLink>false</UseLldLink>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'" Label="LLVM">
     <UseClangCl>false</UseClangCl>
     <ClangClAdditionalOptions>-std=c++11 -Wc++11-narrowing -fsyntax-only  -Wmicrosoft-include -v --relocatable-pch -Wall -Wextra -pedantic</ClangClAdditionalOptions>
     <UseLldLink>false</UseLldLink>
@@ -123,6 +166,7 @@
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)additional\lua\lib;$(BOOST_LIBRARYDIR);$(SolutionDir)additional\assimp\lib;$(SolutionDir)Weave_Engine\_Output\$(Platform)\$(Configuration)</AdditionalLibraryDirectories>
       <AdditionalDependencies>assimp-vc140-mt.lib;lua52.lib;Weave_Engine.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AssemblyDebug>true</AssemblyDebug>
     </Link>
     <PostBuildEvent>
       <Command>xcopy /e /d /h /s /y /i "$(SolutionDir)Assets" "$(OutDir)Assets"
@@ -169,7 +213,63 @@ xcopy /e /d /y "$(SolutionDir)additional\assimp\lib\assimp-vc140-mt.dll" "$(OutD
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <PreprocessorDefinitions>_MBCS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>false</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>$(SolutionDir)additional\imgui;$(SolutionDir)additional\spdlog\include;$(SolutionDir)additional\json;$(SolutionDir)additional\LuaBridge\Source;$(SolutionDir)additional\lua\include;$(SolutionDir)additional\sol2;$(BOOST_ROOT);$(SolutionDir)additional\assimp\include;$(SolutionDir)..\Weave_Common;$(SolutionDir)Weave_Engine;$(SolutionDir)TankGame</AdditionalIncludeDirectories>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <EnableParallelCodeGeneration>false</EnableParallelCodeGeneration>
+      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)additional\lua\lib;$(BOOST_LIBRARYDIR);$(SolutionDir)additional\assimp\lib;$(SolutionDir)Weave_Engine\_Output\$(Platform)\$(Configuration)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>assimp-vc140-mt.lib;lua52.lib;Weave_Engine.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>xcopy /e /d /h /s /y /i "$(SolutionDir)Assets" "$(OutDir)Assets"
+xcopy /e /d /y "$(SolutionDir)additional\lua\lib\lua52.dll" "$(OutDir)"
+xcopy /e /d /y "$(SolutionDir)additional\assimp\lib\assimp-vc140-mt.dll" "$(OutDir)"</Command>
+      <Message>Copy the assets of the game to the output directory</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
@@ -196,6 +296,7 @@ xcopy /e /d /y "$(SolutionDir)additional\assimp\lib\assimp-vc140-mt.dll" "$(OutD
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)additional\lua\lib;$(BOOST_LIBRARYDIR);$(SolutionDir)additional\assimp\lib;$(SolutionDir)Weave_Engine\_Output\$(Platform)\$(Configuration)</AdditionalLibraryDirectories>
       <AdditionalDependencies>assimp-vc140-mt.lib;lua52.lib;Weave_Engine.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AssemblyDebug>true</AssemblyDebug>
     </Link>
     <PostBuildEvent>
       <Command>xcopy /e /d /h /s /y /i "$(SolutionDir)Assets" "$(OutDir)Assets"
@@ -220,11 +321,14 @@ xcopy /e /d /y "$(SolutionDir)additional\assimp\lib\assimp-vc140-mt.dll" "$(OutD
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="Main.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">Use</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -242,37 +346,49 @@ xcopy /e /d /y "$(SolutionDir)additional\assimp\lib\assimp-vc140-mt.dll" "$(OutD
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">5.0</ShaderModel>
     </FxCompile>
     <FxCompile Include="..\Weave_Engine\PixelShader.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">5.0</ShaderModel>
     </FxCompile>
     <FxCompile Include="..\Weave_Engine\PixelShader_Unlit.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">5.0</ShaderModel>
     </FxCompile>
     <FxCompile Include="..\Weave_Engine\SkyPS.hlsl">
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">Pixel</ShaderType>
     </FxCompile>
     <FxCompile Include="..\Weave_Engine\SkyVS.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">Vertex</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">5.0</ShaderModel>
     </FxCompile>
     <FxCompile Include="..\Weave_Engine\VertexShader.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">Vertex</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">5.0</ShaderModel>
     </FxCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Weave_Engine/Weave_Engine.sln
+++ b/Weave_Engine/Weave_Engine.sln
@@ -11,16 +11,21 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Release|x64 = Release|x64
+		RelWithDebugInfo|x64 = RelWithDebugInfo|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EE668F6A-773C-44FD-ACEE-26F997AF51E2}.Debug|x64.ActiveCfg = Debug|x64
 		{EE668F6A-773C-44FD-ACEE-26F997AF51E2}.Debug|x64.Build.0 = Debug|x64
 		{EE668F6A-773C-44FD-ACEE-26F997AF51E2}.Release|x64.ActiveCfg = Release|x64
 		{EE668F6A-773C-44FD-ACEE-26F997AF51E2}.Release|x64.Build.0 = Release|x64
+		{EE668F6A-773C-44FD-ACEE-26F997AF51E2}.RelWithDebugInfo|x64.ActiveCfg = RelWithDebugInfo|x64
+		{EE668F6A-773C-44FD-ACEE-26F997AF51E2}.RelWithDebugInfo|x64.Build.0 = RelWithDebugInfo|x64
 		{3A28292B-0155-4583-BB89-B643E9C639FE}.Debug|x64.ActiveCfg = Debug|x64
 		{3A28292B-0155-4583-BB89-B643E9C639FE}.Debug|x64.Build.0 = Debug|x64
 		{3A28292B-0155-4583-BB89-B643E9C639FE}.Release|x64.ActiveCfg = Release|x64
 		{3A28292B-0155-4583-BB89-B643E9C639FE}.Release|x64.Build.0 = Release|x64
+		{3A28292B-0155-4583-BB89-B643E9C639FE}.RelWithDebugInfo|x64.ActiveCfg = RelWithDebugInfo|x64
+		{3A28292B-0155-4583-BB89-B643E9C639FE}.RelWithDebugInfo|x64.Build.0 = RelWithDebugInfo|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Weave_Engine/Weave_Engine/Core/Game.cpp
+++ b/Weave_Engine/Weave_Engine/Core/Game.cpp
@@ -39,7 +39,7 @@ Game::Game( HINSTANCE hInstance )
     vertexShader = 0;
     pixelShader = 0;
 
-#if defined( DEBUG ) || defined( _DEBUG )
+#if defined( DEBUG ) || defined( _DEBUG ) || defined ( W_ENABLE_LOGGING )
     // Do we want a console window?  Probably only in debug mode
     CreateConsoleWindow( 500, 120, 32, 120 );
     printf( "Console window created successfully.  Feel free to printf() here.\n" );

--- a/Weave_Engine/Weave_Engine/Scenes/Scene.cpp
+++ b/Weave_Engine/Weave_Engine/Scenes/Scene.cpp
@@ -29,7 +29,7 @@ Scene::~Scene()
 void SceneManagement::Scene::Read( InputMemoryBitStream & inInputStream )
 {
     // Read in the array of entity info
-    UINT32 numEntities = {};
+    UINT32 numEntities = 0;
     inInputStream.Read( numEntities );
 
     LOG_TRACE( "Num entities on server scene: {}", numEntities );

--- a/Weave_Engine/Weave_Engine/Weave_Engine.vcxproj
+++ b/Weave_Engine/Weave_Engine/Weave_Engine.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebugInfo|Win32">
+      <Configuration>RelWithDebugInfo</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebugInfo|x64">
+      <Configuration>RelWithDebugInfo</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
@@ -38,6 +46,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>llvm</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -45,6 +60,13 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>llvm</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>llvm</PlatformToolset>
@@ -62,10 +84,16 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -82,6 +110,13 @@
     <LinkIncremental>false</LinkIncremental>
     <CustomBuildAfterTargets />
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">
+    <OutDir>$(ProjectDir)_Output\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>_Intermediate\$(Platform)\$(Configuration)\</IntDir>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
+    <LinkIncremental>false</LinkIncremental>
+    <CustomBuildAfterTargets />
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
     <IntDir>_Intermediate\$(Platform)\$(Configuration)\</IntDir>
@@ -89,6 +124,13 @@
     <CustomBuildAfterTargets />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(ProjectDir)_Output\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>_Intermediate\$(Platform)\$(Configuration)\</IntDir>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
+    <LinkIncremental>false</LinkIncremental>
+    <CustomBuildAfterTargets />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">
     <OutDir>$(ProjectDir)_Output\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>_Intermediate\$(Platform)\$(Configuration)\</IntDir>
     <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
@@ -110,7 +152,17 @@
     <UseClangCl>false</UseClangCl>
     <UseLldLink>false</UseLldLink>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'" Label="LLVM">
+    <ClangClAdditionalOptions>-std=c++11 -Wc++11-narrowing -fsyntax-only  -Wmicrosoft-include -v --relocatable-pch </ClangClAdditionalOptions>
+    <UseClangCl>false</UseClangCl>
+    <UseLldLink>false</UseLldLink>
+  </PropertyGroup>
   <PropertyGroup Label="LLVM" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClangClAdditionalOptions>-std=c++11 -Wc++11-narrowing -fsyntax-only  -Wmicrosoft-include -v --relocatable-pch -Wall -Wextra -pedantic</ClangClAdditionalOptions>
+    <UseClangCl>false</UseClangCl>
+    <UseLldLink>false</UseLldLink>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'" Label="LLVM">
     <ClangClAdditionalOptions>-std=c++11 -Wc++11-narrowing -fsyntax-only  -Wmicrosoft-include -v --relocatable-pch -Wall -Wextra -pedantic</ClangClAdditionalOptions>
     <UseClangCl>false</UseClangCl>
     <UseLldLink>false</UseLldLink>
@@ -229,7 +281,90 @@ xcopy /e /d /y "$(SolutionDir)additional\lua\lib\lua52.dll" "$(OutDir)"</Command
       <Command>xcopy /e /h /y /i "$(SolutionDir)Assets" "$(OutDir)Assets"</Command>
     </CustomBuildStep>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)additional\imgui;$(SolutionDir)additional\spdlog\include;$(SolutionDir)additional\json;$(SolutionDir)additional\LuaBridge\Source;$(SolutionDir)additional\lua\include;$(SolutionDir)additional\sol2;$(BOOST_ROOT);$(SolutionDir)additional\assimp\include</AdditionalIncludeDirectories>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>../stdafx.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableParallelCodeGeneration>false</EnableParallelCodeGeneration>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(SolutionDir)additional\lua\lib;$(BOOST_LIBRARYDIR);$(SolutionDir)additional\assimp\lib\x86</AdditionalLibraryDirectories>
+      <AdditionalDependencies>assimp.lib;lua52.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Message>Copy the assets of the game to the output directory</Message>
+      <Command>xcopy /e /d /h /s /y /i "$(SolutionDir)Assets" "$(OutDir)Assets"
+xcopy /e /d /y "$(SolutionDir)additional\lua\lib\lua52.dll" "$(OutDir)"</Command>
+    </PostBuildEvent>
+    <PreLinkEvent>
+      <Command>
+      </Command>
+    </PreLinkEvent>
+    <PreLinkEvent>
+      <Message>
+      </Message>
+    </PreLinkEvent>
+    <CustomBuildStep>
+      <Command>xcopy /e /h /y /i "$(SolutionDir)Assets" "$(OutDir)Assets"</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)additional\imgui;$(SolutionDir)additional\spdlog\include;$(SolutionDir)additional\json;$(SolutionDir)additional\LuaBridge\Source;$(SolutionDir)additional\lua\include;$(SolutionDir)additional\sol2;$(BOOST_ROOT);$(SolutionDir)additional\assimp\include;$(SolutionDir)..\Weave_Common;$(SolutionDir)Weave_Engine</AdditionalIncludeDirectories>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableParallelCodeGeneration>false</EnableParallelCodeGeneration>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AssemblerOutput>AssemblyAndSourceCode</AssemblerOutput>
+      <PreprocessorDefinitions>_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(SolutionDir)additional\lua\lib;$(BOOST_LIBRARYDIR);$(SolutionDir)additional\assimp\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>assimp-vc140-mt.lib;lua52.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Message>Copy the assets of the game to the output directory</Message>
+      <Command>xcopy /e /d /h /s /y /i "$(SolutionDir)Assets" "$(OutDir)Assets"
+xcopy /e /d /y "$(SolutionDir)additional\lua\lib\lua52.dll" "$(OutDir)"
+xcopy /e /d /y "$(SolutionDir)additional\assimp\lib\assimp-vc140-mt.dll" "$(OutDir)"</Command>
+    </PostBuildEvent>
+    <PreLinkEvent>
+      <Command>
+      </Command>
+    </PreLinkEvent>
+    <PreLinkEvent>
+      <Message>
+      </Message>
+    </PreLinkEvent>
+    <CustomBuildStep>
+      <Command>xcopy /e /h /y /i "$(SolutionDir)Assets" "$(OutDir)Assets"</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
@@ -281,48 +416,62 @@ xcopy /e /d /y "$(SolutionDir)additional\assimp\lib\assimp-vc140-mt.dll" "$(OutD
     <ClCompile Include="..\..\Weave_Common\MemoryBitStream.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\Weave_Common\Networking\NetworkManager.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)Weave_Engine;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)Weave_Engine;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">$(SolutionDir)Weave_Engine;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="..\..\Weave_Common\Scenes\IScene.cpp" />
     <ClCompile Include="..\..\Weave_Common\stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\Weave_Common\Timing.cpp" />
     <ClCompile Include="..\additional\imgui\imgui\imgui.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="..\additional\imgui\imgui\imgui_draw.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="..\additional\imgui\imgui\imgui_impl_dx11.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="..\additional\imgui\imgui\imgui_impl_win32.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="..\additional\imgui\imgui\imgui_widgets.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="Camera\Camera.cpp" />
     <ClCompile Include="Camera\CameraManager.cpp" />
@@ -342,6 +491,7 @@ xcopy /e /d /y "$(SolutionDir)additional\assimp\lib\assimp-vc140-mt.dll" "$(OutD
     <ClCompile Include="Resources\Materials\Material.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../../stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">../../stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">../../stdafx.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="Resources\Mesh.cpp" />
     <ClCompile Include="Resources\MeshRenderer.cpp" />

--- a/Weave_Server/Weave_Server/include/ServerNetworkManager.h
+++ b/Weave_Server/Weave_Server/include/ServerNetworkManager.h
@@ -11,7 +11,7 @@ class ServerNetworkManager : public NetworkManager
 {
 public:
 
-    ServerNetworkManager();
+    ServerNetworkManager( std::shared_ptr< boost::asio::io_service > aServce );
 
     virtual ~ServerNetworkManager();
 

--- a/Weave_Server/Weave_Server/include/WeaveServer.h
+++ b/Weave_Server/Weave_Server/include/WeaveServer.h
@@ -4,6 +4,7 @@
 #include <thread>
 #include <memory>
 #include <unordered_map>
+#include <boost/asio.hpp>
 
 #include "ServerNetworkManager.h"
 
@@ -77,6 +78,8 @@ private:
 
     /** The thread the user input will be checked on */
     std::thread userInputThread;
+
+    std::shared_ptr < boost::asio::io_service > io_service;
 
     /** Delta time of the server */
     float DeltaTime;

--- a/Weave_Server/Weave_Server/include/WeaveServer.h
+++ b/Weave_Server/Weave_Server/include/WeaveServer.h
@@ -79,6 +79,10 @@ private:
     /** The thread the user input will be checked on */
     std::thread userInputThread;
 
+    /** Pointer to the io_service for the network manager 
+    * This has to be here because otherwise there is an exception on exit
+    * in release mode when the netMan io_service goes out of context
+    */
     std::shared_ptr < boost::asio::io_service > io_service;
 
     /** Delta time of the server */

--- a/Weave_Server/Weave_Server/src/Main.cpp
+++ b/Weave_Server/Weave_Server/src/Main.cpp
@@ -41,11 +41,13 @@ int main( int argc, char* argv [] )
     try
     {
         // Create the server 
-        std::unique_ptr< WeaveServer > Server =
-            std::make_unique< WeaveServer >( serverDesc );
+        //std::unique_ptr< WeaveServer > Server =
+        //    std::make_unique< WeaveServer >( serverDesc );
+
+        WeaveServer Server( serverDesc );
 
         // run the server
-        Server->Run();
+        //Server->Run();
     }
     catch ( const std::exception& e )
     {

--- a/Weave_Server/Weave_Server/src/Main.cpp
+++ b/Weave_Server/Weave_Server/src/Main.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <string>       // std::string
 #include <thread>       // std::thread
-#include <memory>       // std::unique_ptr
+#include <memory>       // std::unique_ptr, std::shared_ptr
 #include <fstream>
 #include <assert.h>
 

--- a/Weave_Server/Weave_Server/src/Main.cpp
+++ b/Weave_Server/Weave_Server/src/Main.cpp
@@ -47,7 +47,7 @@ int main( int argc, char* argv [] )
         WeaveServer Server( serverDesc );
 
         // run the server
-        //Server->Run();
+        Server.Run();
     }
     catch ( const std::exception& e )
     {

--- a/Weave_Server/Weave_Server/src/ServerNetworkManager.cpp
+++ b/Weave_Server/Weave_Server/src/ServerNetworkManager.cpp
@@ -2,8 +2,8 @@
 
 #include "ServerNetworkManager.h"
 
-ServerNetworkManager::ServerNetworkManager()
-    : NetworkManager()
+ServerNetworkManager::ServerNetworkManager( std::shared_ptr< boost::asio::io_service > aServce )
+    : NetworkManager( aServce )
 {
     // Create a scene to replicate
 

--- a/Weave_Server/Weave_Server/src/WeaveServer.cpp
+++ b/Weave_Server/Weave_Server/src/WeaveServer.cpp
@@ -12,8 +12,9 @@ WeaveServer::WeaveServer( SERVER_INIT_DESC aDesc )
     // #TODO: Set up a room concept for the server
     ( void )( ResponsePort );
     ( void )( MaxRooms );
+    io_service = std::make_shared<boost::asio::io_service>();
 
-    NetworkMan = new ServerNetworkManager();
+    NetworkMan = new ServerNetworkManager( io_service );
     NetworkMan->Init( ListenPort );
 
     // Add user command options


### PR DESCRIPTION
The problem was occurring because the `io_context` was being used in some async operations after the destruction of it. Solved this problem by not creating the `io_context` in the `NetworkManager`, and just have the NetMan take in a reference to one. 